### PR TITLE
test-code-update: en locale doesn't work but properties file with en

### DIFF
--- a/ecuacion-lib-core/src/test/java/jp/ecuacion/lib/core/util/internal/Test91_12_util_PropertyFileUtilValueGetter.java
+++ b/ecuacion-lib-core/src/test/java/jp/ecuacion/lib/core/util/internal/Test91_12_util_PropertyFileUtilValueGetter.java
@@ -261,13 +261,13 @@ public class Test91_12_util_PropertyFileUtilValueGetter extends TestTools {
   @Test
   public void test31_複数locale_11_ファイル_localeなし_言語_01_client_locale_同一言語and国() {
     PropertyFileUtilValueGetter store = new PropertyFileUtilValueGetter(new String[][] {new String[] {"test92-none-and-lang"}});
-    Assertions.assertThat(store.getProp(Locale.US, "FILE_LOCALE")).isEqualTo("en");
+    Assertions.assertThat(store.getProp(Locale.ITALIAN, "FILE_LOCALE")).isEqualTo("it");
   }
 
   @Test
   public void test31_複数locale_11_ファイル_localeなし_言語_02_client_locale_同一言語() {
     PropertyFileUtilValueGetter store = new PropertyFileUtilValueGetter(new String[][] {new String[] {"test92-none-and-lang"}});
-    Assertions.assertThat(store.getProp(Locale.ENGLISH, "FILE_LOCALE")).isEqualTo("en");
+      Assertions.assertThat(store.getProp(Locale.ITALY, "FILE_LOCALE")).isEqualTo("it");
   }
 
   @Test

--- a/ecuacion-lib-core/src/test/resources/test92-none-and-lang_en.properties
+++ b/ecuacion-lib-core/src/test/resources/test92-none-and-lang_en.properties
@@ -1,1 +1,0 @@
-FILE_LOCALE=en

--- a/ecuacion-lib-core/src/test/resources/test92-none-and-lang_it.properties
+++ b/ecuacion-lib-core/src/test/resources/test92-none-and-lang_it.properties
@@ -1,0 +1,1 @@
+FILE_LOCALE=it


### PR DESCRIPTION
locale never use bacause en is always default.