### PR TITLE
#368: PropertyFileUtil.getItemName now don't cause Exceptions when the

### DIFF
--- a/ecuacion-lib-core/src/main/java/jp/ecuacion/lib/core/util/internal/PropertyFileUtilFileKindEnum.java
+++ b/ecuacion-lib-core/src/main/java/jp/ecuacion/lib/core/util/internal/PropertyFileUtilFileKindEnum.java
@@ -39,35 +39,41 @@ package jp.ecuacion.lib.core.util.internal;
 public enum PropertyFileUtilFileKindEnum {
 
   /** application.properties. */
-  APP("application", new String[][] {new String[] {"application"}}),
+  APP("application", new String[][] {new String[] {"application"}}, true),
 
   /** 
    * messages.properties. 
    */
-  MSG("messages", new String[][] {new String[] {"messages"}}),
+  MSG("messages", new String[][] {new String[] {"messages"}}, false),
 
   /** itemの名称を記述. */
-  ITEM_NAME("item_names", new String[][] {new String[] {"item_names"}}),
+  ITEM_NAME("item_names", new String[][] {new String[] {"item_names"}}, false),
 
   /** enumの名称を記述. */
-  ENUM_NAME("enum_names", new String[][] {new String[] {"enum_names"}}),
+  ENUM_NAME("enum_names", new String[][] {new String[] {"enum_names"}}, false),
 
   /** ValidationMessags */
-  VALIDATION_MESSAGES("ValidationMessages", new String[][] {new String[] {"ValidationMessages"}}),
+  VALIDATION_MESSAGES("ValidationMessages", new String[][] {new String[] {"ValidationMessages"}},
+      false),
 
   /** ValidationMessagsWithField */
-  VALIDATION_MESSAGES_WITH_ITEM_NAMES("ValidationMessagesWithItemNames", new String[][] {
-      new String[] {"ValidationMessagesWithItemNames"}, new String[] {"ValidationMessages"}}),
+  VALIDATION_MESSAGES_WITH_ITEM_NAMES(
+      "ValidationMessagesWithItemNames", new String[][] {
+          new String[] {"ValidationMessagesWithItemNames"}, new String[] {"ValidationMessages"}},
+      false),
 
   VALIDATION_MESSAGES_PATTERN_DESCRIPTIONS("ValidationMessagesPatternDescriptions",
-      new String[][] {new String[] {"ValidationMessagesPatternDescriptions"}});
+      new String[][] {new String[] {"ValidationMessagesPatternDescriptions"}}, false);
 
   private String filePrefix;
   private String[][] actualFilePrefixes;
+  private boolean throwsExceptionWhenKeyDoesNotExist;
 
-  private PropertyFileUtilFileKindEnum(String filePrefix, String[][] actualFilePrefixes) {
+  private PropertyFileUtilFileKindEnum(String filePrefix, String[][] actualFilePrefixes,
+      boolean throwsExceptionWhenKeyDoesNotExist) {
     this.filePrefix = filePrefix;
     this.actualFilePrefixes = actualFilePrefixes;
+    this.throwsExceptionWhenKeyDoesNotExist = throwsExceptionWhenKeyDoesNotExist;
   }
 
   public String getFilePrefix() {
@@ -76,6 +82,10 @@ public enum PropertyFileUtilFileKindEnum {
 
   public String[][] getActualFilePrefixes() {
     return actualFilePrefixes;
+  }
+
+  public boolean throwsExceptionWhenKeyDoesNotExist() {
+    return throwsExceptionWhenKeyDoesNotExist;
   }
 
   public static PropertyFileUtilFileKindEnum getEnumFromFilePrefix(String filePrefix) {

--- a/ecuacion-lib-core/src/main/java/jp/ecuacion/lib/core/util/internal/PropertyFileUtilValueGetter.java
+++ b/ecuacion-lib-core/src/main/java/jp/ecuacion/lib/core/util/internal/PropertyFileUtilValueGetter.java
@@ -54,6 +54,7 @@ import org.apache.commons.lang3.tuple.Pair;
  */
 public class PropertyFileUtilValueGetter {
 
+  private boolean throwsExceptionWhenKeyDoesNotExist;
   /*
    * kindの中にfilePrefixを持っているので冗長な持ち方なのだが、
    * テストでPropertyFileUtilPropFileKindEnumにないfilePrefixを使用したい場合があるため別で持つ。
@@ -113,6 +114,7 @@ public class PropertyFileUtilValueGetter {
    */
   public PropertyFileUtilValueGetter(@RequireNonnull PropertyFileUtilFileKindEnum fileKindEnum) {
     this.filePrefixes = ObjectsUtil.paramRequireNonNull(fileKindEnum).getActualFilePrefixes();
+    this.throwsExceptionWhenKeyDoesNotExist = fileKindEnum.throwsExceptionWhenKeyDoesNotExist();
   }
 
   /*
@@ -409,7 +411,17 @@ public class PropertyFileUtilValueGetter {
       throw new EclibRuntimeException("Message ID is blank.");
     }
 
-    return getValue(locale, key);
+    try {
+      return getValue(locale, key);
+      
+    } catch (NoKeyInPropertiesFileException ex) {
+      if (throwsExceptionWhenKeyDoesNotExist) {
+        throw ex;
+
+      } else {
+        return "[ " + key + " ]";
+      } 
+    }
   }
 
   private static class NoKeyInPropertiesFileException extends EclibRuntimeException {


### PR DESCRIPTION
key does not exist.