### PR TITLE
jakarta.validation.constraints.NotEmpty / NotNull.message unneeded in ecuacion-lib-core

### DIFF
--- a/ecuacion-lib-core/src/main/resources/messages_lib_core.properties
+++ b/ecuacion-lib-core/src/main/resources/messages_lib_core.properties
@@ -1,7 +1,5 @@
 # validator
 ## common
-jakarta.validation.constraints.NotEmpty.message.default        = must not be empty
-jakarta.validation.constraints.NotNull.message.default         = must not be null
 jp.ecuacion.lib.core.jakartavalidation.validator.displayStringForHiddenValue.default=(hidden)
 
 # message parts

--- a/ecuacion-lib-core/src/main/resources/messages_lib_core_ja.properties
+++ b/ecuacion-lib-core/src/main/resources/messages_lib_core_ja.properties
@@ -1,7 +1,5 @@
 # validator
 ## common
-jakarta.validation.constraints.NotEmpty.message.default        = 入力必須です
-jakarta.validation.constraints.NotNull.message.default         = 入力必須です
 jp.ecuacion.lib.core.jakartavalidation.validator.displayStringForHiddenValue.default=（非表示）
 
 # message parts

--- a/ecuacion-lib-core/src/main/resources/messages_with_item_names_lib_core.properties
+++ b/ecuacion-lib-core/src/main/resources/messages_with_item_names_lib_core.properties
@@ -1,4 +1,0 @@
-# validator
-## common
-jakarta.validation.constraints.NotEmpty.message.default        = {item_name} must not be empty.
-jakarta.validation.constraints.NotNull.message.default         = {item_name} must not be null.

--- a/ecuacion-lib-core/src/main/resources/messages_with_item_names_lib_core_ja.properties
+++ b/ecuacion-lib-core/src/main/resources/messages_with_item_names_lib_core_ja.properties
@@ -1,4 +1,0 @@
-# validator
-## common
-jakarta.validation.constraints.NotEmpty.message.default        = {item_name}は入力必須です
-jakarta.validation.constraints.NotNull.message.default         = {item_name}は入力必須です


### PR DESCRIPTION
- NotEmpty message is used in splib-web so it's moved there
- NotNull message not needed so it's removed
